### PR TITLE
ExtensionAttribute  shold not be redeclared when it is not needed

### DIFF
--- a/src/Spring.Core.Configuration/Context/Extension/ApplicationContextExtensions.cs
+++ b/src/Spring.Core.Configuration/Context/Extension/ApplicationContextExtensions.cs
@@ -20,6 +20,7 @@
 
 using Spring.Objects.Factory;
 
+#if(! DotNetVersion35)
 
 namespace System.Runtime.CompilerServices
 {
@@ -32,8 +33,7 @@ namespace System.Runtime.CompilerServices
     }
 }
 
-
-
+#endif
 
 
 namespace Spring.Context

--- a/src/Spring.Core.Configuration/Spring.Core.Configuration.2010.csproj
+++ b/src/Spring.Core.Configuration/Spring.Core.Configuration.2010.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\build\net-2.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DotNetVersion35</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\build\net-2.0\Spring.Core.Configuration.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\build\net-2.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;DotNetVersion35</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\build\net-2.0\Spring.Core.Configuration.XML</DocumentationFile>


### PR DESCRIPTION
Redeclaring the ExtensionAttribute is not always just a "harmless warning" that you can ignore at the cost of being a slob who ignores warnings, it actually prevents some code from building. It's a pain in the neck, same issue as http://stackoverflow.com/questions/4353335/mono-cecil-missing-compiler-required-member-system-runtime-compilerservices-ext 

This causes the c# compiler to emit:
"error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.ExtensionAttribute..ctor'"

The docs on this error number say:"You have a reference to an assembly that defines a type that is also found in the common language runtime. However, your assembly's type is not defined the way the C# compiler expects."

It has the same fix.  I wrapped it in a preprocessor directive. Ensure that the symbol DotNetVersion35 is defined when building for framework V3.5 and up, and the erroneous def. will not be added.
